### PR TITLE
wiener_c: improve the wiener filter using loop interchange

### DIFF
--- a/src/looprestoration_tmpl.c
+++ b/src/looprestoration_tmpl.c
@@ -172,8 +172,8 @@ static void wiener_c(pixel *p, const ptrdiff_t p_stride,
     const int round_bits_v = 11 - (bitdepth == 12) * 2;
     const int rounding_off_v = 1 << (round_bits_v - 1);
     const int round_offset = 1 << (bitdepth + (round_bits_v - 1));
-    for (int i = 0; i < w; i++) {
-        for (int j = 0; j < h; j++) {
+    for (int j = 0; j < h; j++) {
+        for (int i = 0; i < w; i++) {
             int sum = (hor[(j + 3) * REST_UNIT_STRIDE + i] << 7) - round_offset;
 
             for (int k = 0; k < 7; k++) {


### PR DESCRIPTION
Power 9:
Before: wiener_chroma_8bpc_c: 60703.6
After: wiener_chroma_8bpc_c: 34722.0

Before: wiener_luma_8bpc_c: 66668.4
After: wiener_luma_8bpc_vsx: 29622.4

Ryzen 1600

Before: wiener_chroma_8bpc_c: 254139.8
After: wiener_chroma_8bpc_c: 183539.8

Before: wiener_luma_8bpc_c: 253076.8
After: wiener_luma_8bpc_c: 181877.8